### PR TITLE
Ensure destination directory exists

### DIFF
--- a/PandocMan.cmake
+++ b/PandocMan.cmake
@@ -111,6 +111,10 @@ function(add_pandoc_man SRC)
     message(FATAL_ERROR "File name of a man page must be in the format {name}.{man-number}${MD_EXT}.")
   endif()
 
+  # Ensure destination directory exists
+  get_filename_component(DEST_DIR ${DST} DIRECTORY)
+  file(MAKE_DIRECTORY "${DEST_DIR}")
+
   add_custom_command(
     OUTPUT ${DST}
     COMMAND ${PANDOCCOMMAND_PATH} -s -t man ${SRC} -o ${DST}


### PR DESCRIPTION
Hey, thank you for this very useful script! I hit an error when I first tried to use it because the output man page path didn't exist and Pandoc doesn't automatically create it. This small change ensures that the path will exist when Pandoc tries to write to it.